### PR TITLE
Feature/27 calls interaction

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -56,7 +56,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['spec'],
 
 
     // web server port

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-jasmine": "^0.3.5",
     "karma-jspm": "2.0.1-beta.2",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-spec-reporter": "0.0.22",
     "object.assign": "^1.0.3",
     "phantomjs": "^1.9.18",
     "require-dir": "^0.1.0",

--- a/src/graph-menu/graph-menu.html
+++ b/src/graph-menu/graph-menu.html
@@ -28,11 +28,11 @@
       </div>
 
       <div class="interaction">
-        <label>Instantiation</label>
+        <label>Ownership</label>
         <label repeat.for="opt of graphInteractionModel.options">
           <input type="radio"
               value.bind="opt"
-              checked.bind="$parent.graphInteractionModel.instantiationSelectedVal" />
+              checked.bind="$parent.graphInteractionModel.ownershipSelectedVal" />
             ${opt}
         </label>
       </div>

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -110,4 +110,19 @@ export class GraphFinder {
     return results;
   }
 
+  /**
+   * Return nodes that are not already in graph
+   */
+  filterAlreadyInGraph(nodes, graph) {
+    let results = [];
+
+    nodes.forEach( nodeId => {
+      if (!graph.hasNode(nodeId)) {
+        results.push(nodeId);
+      }
+    });
+
+    return results;
+  }
+
 }

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -1,4 +1,4 @@
-export default class GraphFinder {
+export class GraphFinder {
 
   getMembers(graph, nodeId) {
     return graph

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -83,12 +83,30 @@ export class GraphFinder {
     });
   }
 
-  findSelectedNodes(graph) {
+  findSelectedNodeIds(graph) {
     return graph.nodes().filter( nodeId => graph.node(nodeId).selectStatus === 'selected' );
   }
 
-  findNodes(graph, selectedNode, edgeKind, relationship) {
+  /**
+   * https://github.com/cpettitt/graphlib/wiki/API-Reference#node-and-edge-representation
+   *  v: the id of the source or tail node of an edge
+   *  w: the id of the target or head node of an edge
+   */
+  findNodesByEdgeRelationship(graph, selectedNodeIds, edgeKind, relationship) {
+    let results = [],
+      edgeProperty = relationship === 'target' ? 'w' : 'v';
 
+    selectedNodeIds.forEach( nodeId => {
+      let edges = graph.nodeEdges(nodeId).filter( edge => {
+        let currentEdge = graph.edge(edge);
+        return currentEdge.edgeKind === edgeKind && edge[edgeProperty] === nodeId;
+      });
+      edges.forEach( edge => {
+        results.push(edge[edgeProperty]);
+      });
+    });
+
+    return results;
   }
 
 }

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -81,6 +81,13 @@ export class GraphFinder {
     return projectTypeNodes.filter(nodeId => {
       return this.typeUsersCount(graph, nodeId) === 0;
     });
+  }
+
+  findSelectedNodes(graph) {
+    return graph.nodes().filter( nodeId => graph.node(nodeId).selectStatus === 'selected' );
+  }
+
+  findNodes(graph, selectedNode, edgeKind, relationship) {
 
   }
 

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -100,7 +100,6 @@ export class GraphFinder {
     selectedNodeIds.forEach( nodeId => {
       let edges = graph.nodeEdges(nodeId).filter( edge => {
         let currentEdge = graph.edge(edge);
-        console.log(`nodeId: ${nodeId}, edge: ${JSON.stringify(edge)}, edgeProperty: ${edgeProperty}`);
         return currentEdge.edgeKind === edgeKind && edge[edgeProperty] === nodeId;
       });
       edges.forEach( edge => {

--- a/src/graph/graph-finder.js
+++ b/src/graph/graph-finder.js
@@ -94,15 +94,17 @@ export class GraphFinder {
    */
   findNodesByEdgeRelationship(graph, selectedNodeIds, edgeKind, relationship) {
     let results = [],
-      edgeProperty = relationship === 'target' ? 'w' : 'v';
+      edgeProperty = relationship === 'target' ? 'w' : 'v',
+      returnProperty = relationship === 'target' ? 'v' : 'w';
 
     selectedNodeIds.forEach( nodeId => {
       let edges = graph.nodeEdges(nodeId).filter( edge => {
         let currentEdge = graph.edge(edge);
+        console.log(`nodeId: ${nodeId}, edge: ${JSON.stringify(edge)}, edgeProperty: ${edgeProperty}`);
         return currentEdge.edgeKind === edgeKind && edge[edgeProperty] === nodeId;
       });
       edges.forEach( edge => {
-        results.push(edge[edgeProperty]);
+        results.push(edge[returnProperty]);
       });
     });
 

--- a/src/graph/graph-modifier.js
+++ b/src/graph/graph-modifier.js
@@ -80,10 +80,20 @@ export default class GraphModifier {
     return graph;
   }
 
+  addNodeOnly(graph, id, svgText) {
+    this.addNodeToDisplay(graph, id, svgText);
+    return graph;
+  }
+
   // https://github.com/cpettitt/graphlib/wiki/API-Reference
   removeNodeEnv(graph, id, degree, svgText) {
     graph.removeNode(id);
     this.removeNodeNeighbors(graph, id);
+    return graph;
+  }
+
+  removeNodeOnly(graph, id, svgText) {
+    graph.removeNode(id);
     return graph;
   }
 

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -33,6 +33,7 @@ export class Graph {
     this.actionManager = ActionManager;
 
     this.initSvg();
+    this.registerKeyHandlers();
 
     this.pubSub.subscribe('search.node', nodeId => {
       this.addNodeAction(nodeId);
@@ -74,6 +75,20 @@ export class Graph {
 
     this.initForceLayout();
     this.windowSizeAdapter();
+  }
+
+  registerKeyHandlers(evt) {
+    document.onkeydown = (evt) => {
+      if (evt.keyCode === 17 || evt.keyCode === 91) {
+        this.interactionState.ctrlDown = true;
+      }
+    };
+
+    document.onkeyup = (evt) => {
+      if (evt.keyCode === 17 || evt.keyCode === 91) {
+        this.interactionState.ctrlDown = false;
+      }
+    };
   }
 
   initForceLayout() {
@@ -589,6 +604,8 @@ export class Graph {
 
       bindingEngine.propertyObserver(this.graphInteractionModel, 'callsSelectedVal').subscribe((newValue, oldValue) => {
         console.log(`=== bindingEngine propertyObserver for callsSelectedVal: newValue = ${newValue}, oldValue = ${oldValue}`);
+        console.log(`selected nodes:`);
+        console.table(`${this.graphFinder.findSelectedNodes(this.displayGraph)}`);
       });
 
       bindingEngine.propertyObserver(this.graphInteractionModel, 'extensionsSelectedVal').subscribe((newValue, oldValue) => {

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -601,11 +601,11 @@ export class Graph {
     let selectedNodeIds = this.graphFinder.findSelectedNodeIds(this.displayGraph);
     let relationship = type === 'of it' ? 'target' : 'source';
     let nodesByEdgeRelationship = this.graphFinder.findNodesByEdgeRelationship(
-      this.displayGraph, selectedNodeIds, interaction, relationship
+      this.graphModel.globalGraphModel, selectedNodeIds, interaction, relationship
     );
-    
-    // TODO: Support undo for a "batch" of nodes added to display
-    nodesByEdgeRelationship.forEach( nodeId => this.fireGraphDisplay(nodeId) );
+    // TODO: Before adding to graph, filter out those that are already in display, o.w. undo will be too aggressive
+
+    nodesByEdgeRelationship.forEach( nodeId => this.addNodeAction(nodeId) );
   }
 
   // user requested an interaction with the graph

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -8,7 +8,7 @@ import d3 from 'd3';
 import {ActionManager} from './action-manager';
 import GraphLibD3 from './graphlib-d3';
 import GraphModel from './graph-model';
-import GraphFinder from './graph-finder';
+import {GraphFinder} from './graph-finder';
 import GraphModifier from './graph-modifier';
 import { formattedText, calcBBox } from './graph-text';
 

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -597,23 +597,32 @@ export class Graph {
     }
   }
 
+  addNodesToDisplay(interaction, type) {
+    let selectedNodeIds = this.graphFinder.findSelectedNodeIds(this.displayGraph);
+    let relationship = type === 'of it' ? 'target' : 'source';
+    let nodesByEdgeRelationship = this.graphFinder.findNodesByEdgeRelationship(
+      this.displayGraph, selectedNodeIds, interaction, relationship
+    );
+    
+    // TODO: Support undo for a "batch" of nodes added to display
+    nodesByEdgeRelationship.forEach( nodeId => this.fireGraphDisplay(nodeId) );
+  }
+
   // user requested an interaction with the graph
   graphInteractionModelChanged(newValue) {
     if (newValue) {
       this.graphInteractionModel = newValue;
 
       bindingEngine.propertyObserver(this.graphInteractionModel, 'callsSelectedVal').subscribe((newValue, oldValue) => {
-        console.log(`=== bindingEngine propertyObserver for callsSelectedVal: newValue = ${newValue}, oldValue = ${oldValue}`);
-        console.log(`selected nodes:`);
-        console.table(`${this.graphFinder.findSelectedNodes(this.displayGraph)}`);
+        this.addNodesToDisplay('uses', newValue);
       });
 
       bindingEngine.propertyObserver(this.graphInteractionModel, 'extensionsSelectedVal').subscribe((newValue, oldValue) => {
-        console.log(`=== bindingEngine propertyObserver for extensionsSelectedVal: newValue = ${newValue}, oldValue = ${oldValue}`);
+        this.addNodesToDisplay('extends', newValue);
       });
 
-      bindingEngine.propertyObserver(this.graphInteractionModel, 'instantiationSelectedVal').subscribe((newValue, oldValue) => {
-        console.log(`=== bindingEngine propertyObserver for instantiationSelectedVal: newValue = ${newValue}, oldValue = ${oldValue}`);
+      bindingEngine.propertyObserver(this.graphInteractionModel, 'ownershipSelectedVal').subscribe((newValue, oldValue) => {
+        this.addNodesToDisplay('declares member', newValue);
       });
 
       // TODO dispose in appropriate lifecycle method http://stackoverflow.com/questions/30283569/array-subscription-in-aurelia

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -40,6 +40,10 @@ export class Graph {
     });
   }
 
+  /**
+   * Perform the add action, and register
+   * undo and redo handlers.
+   */
   addNodeAction(nodeIds, withNeighbours) {
     this.addAndDisplay(nodeIds, withNeighbours);
     this.actionManager.addAction(this,
@@ -218,7 +222,6 @@ export class Graph {
 
     this.presentationSVGWidth = width -1;
     this.presentationSVGHeight = height - 1;
-    console.log(`=== windowSizeAdapter: ${this.presentationSVGWidth} x ${this.presentationSVGHeight}`);
     this.presentationSVG
       .attr('width', this.presentationSVGWidth)
       .attr('height', this.presentationSVGHeight);
@@ -344,7 +347,6 @@ export class Graph {
 
       // after the (re)join, fire away the animation of the force layout
       this.forceLayout.start();
-      console.log('forceLayout started');
     }, forceResumeDelay);
 
   }
@@ -375,7 +377,6 @@ export class Graph {
           }
       })
       .on('dblclick', node => {
-        console.log(node.id);
       })
       //
       // mouse over and mouse out events use a named transition (see https://gist.github.com/mbostock/24bdd02df2a72866b0ec)
@@ -482,8 +483,11 @@ export class Graph {
       .style('stroke-width', width);
   }
 
+  /**
+   * Modify the graph display model to include the given node id's.
+   * If withNeihbours is true, then also include each node's neighbours.
+   */
   addToDisplayGraphModel(nodeIds, withNeighbours) {
-    console.log(`addToDisplayGraphModel: ${JSON.stringify(nodeIds)}`);
     nodeIds.forEach( nodeId => {
       if (withNeighbours) {
         this.graphModifier.addNodeEnv(this.displayGraph, nodeId, 1, this.svgText);
@@ -493,8 +497,11 @@ export class Graph {
     });
   }
 
+  /**
+   * Modify the graph display model to remove the given node id's.
+   * If withNeihbours is true, then also remove each node's neighbours.
+   */
   removeFromDisplayGraphModel(nodeIds, withNeighbours) {
-    console.log(`removeFromDisplayGraphModel: ${JSON.stringify(nodeIds)}`);
     nodeIds.forEach( nodeId => {
       if (withNeighbours) {
         this.graphModifier.removeNodeEnv(this.displayGraph, nodeId, 1, this.svgText);
@@ -504,8 +511,10 @@ export class Graph {
     });
   }
 
+  /**
+   * Render the graph, with a transition animation on the newly added nodes.
+   */
   fireGraphDisplay(nodeIds) {
-    console.log(`fireGraphDisplay: ${JSON.stringify(nodeIds)}`);
     nodeIds.forEach( nodeId => {
       let node = this.displayGraph.node(nodeId);
       let selector = '#node' + nodeId;
@@ -525,8 +534,10 @@ export class Graph {
     });
   }
 
+  /**
+   * Render the graph.
+   */
   unfireGraphDisplay() {
-    console.log('unfireGraphDisplay');
     this.updateForceLayout(this.displayGraph, true);
   }
 
@@ -616,7 +627,10 @@ export class Graph {
     this.rewarmForceLayout();
   }
 
-  // A brand new graph
+  /**
+   * Invoked by Aurelia when the 'data' binding changes.
+   * This indicates a new global graph model is available.
+   */
   dataChanged(newValue) {
     if (newValue) {
       // TODO: port from visualizer: applyGraphFilters, debugListSpecialNodes
@@ -630,6 +644,11 @@ export class Graph {
     }
   }
 
+  /**
+   * Based on the currently selected nodes, use 'interaction' and 'type'
+   * to find nodes from globalGraph that should be added, but only if
+   * they're not already in the display graph.
+   */
   findNodesToAdd(interaction, type) {
     let selectedNodeIds,
       relationship,
@@ -658,7 +677,12 @@ export class Graph {
     }
   }
 
-  // user requested an interaction with the graph
+  /**
+   * Invoked by Aurelia when 'graphInteractionModel' binding value has changed.
+   * In practice this object it set once in the parent view. After that,
+   * register property observers to fire when specific properties of the interaction model change,
+   * indicating that the graph should respond to the change by adding more nodes.
+   */
   graphInteractionModelChanged(newValue) {
     if (newValue) {
       this.graphInteractionModel = newValue;

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -630,22 +630,32 @@ export class Graph {
     }
   }
 
-  addNodesToDisplay(interaction, type) {
-    // Determine which nodes need to be added
-    let selectedNodeIds = this.graphFinder.findSelectedNodeIds(this.displayGraph);
-    let relationship = type === 'of it' ? 'target' : 'source';
-    let nodesByEdgeRelationship = this.graphFinder.findNodesByEdgeRelationship(
+  findNodesToAdd(interaction, type) {
+    let selectedNodeIds,
+      relationship,
+      nodesByEdgeRelationship;
+
+    selectedNodeIds = this.graphFinder.findSelectedNodeIds(this.displayGraph);
+    relationship = type === 'of it' ? 'target' : 'source';
+    nodesByEdgeRelationship = this.graphFinder.findNodesByEdgeRelationship(
       this.graphModel.globalGraphModel, selectedNodeIds, interaction, relationship
     );
-    let nodesToAdd = this.graphFinder.filterAlreadyInGraph(nodesByEdgeRelationship, this.displayGraph);
 
-    // TODO Need a better solution to limit the amount displayed
-    let maxNodesToAdd = 10;
-    if (nodesToAdd.length > maxNodesToAdd) {
-      console.warn(`Only 10 of ${nodesToAdd.length} will be added`);
+    return this.graphFinder.filterAlreadyInGraph(nodesByEdgeRelationship, this.displayGraph);
+  }
+
+  /**
+   * Determine nodes that should be added, and add them as an undo-able action.
+   */
+  addNodesToDisplay(interaction, type) {
+    let nodesToAdd = this.findNodesToAdd(interaction, type);
+
+    if (nodesToAdd.length > 0) {
+      this.addNodeAction(nodesToAdd);
+    } else {
+      // TODO notify https://github.com/CANVE/canve-viz/issues/32
+      console.warn('No interaction results');
     }
-
-    this.addNodeAction(nodesToAdd.slice(0, maxNodesToAdd));
   }
 
   // user requested an interaction with the graph

--- a/src/models/graph-interaction-model.js
+++ b/src/models/graph-interaction-model.js
@@ -6,7 +6,7 @@ export class GraphInteractionModel {
 
     this.callsSelectedVal = '';
     this.extensionsSelectedVal = '';
-    this.instantiationSelectedVal = '';
+    this.ownershipSelectedVal = '';
   }
 
 }

--- a/test/unit/graph/graph-finder-spec.js
+++ b/test/unit/graph/graph-finder-spec.js
@@ -107,4 +107,44 @@ describe('GraphFinder', () => {
 
   });
 
+  describe('filterAlreadyInGraph', () => {
+
+    it('filters out nodes that are already in graph', () => {
+      // Given
+      let nodes = ['3', '6', '7'];
+      let graph = new Dagre.graphlib.Graph({ multigraph: true});
+      graph.setNode('1', {name: 'node1', kind: 'Classs', displayName: 'Node 1'});
+      graph.setNode('2', {name: 'node2', kind: 'Classs', displayName: 'Node 2'});
+      graph.setNode('3', {name: 'node3', kind: 'Classs', displayName: 'Node 3'});
+      graph.setNode('4', {name: 'node4', kind: 'Classs', displayName: 'Node 4'});
+      graph.setNode('5', {name: 'node5', kind: 'Classs', displayName: 'Node 5'});
+
+      // When
+      let result = sut.filterAlreadyInGraph(nodes, graph);
+
+      // Then
+      expect(result.length).toEqual(2);
+      expect(result.includes('6')).toBe(true);
+      expect(result.includes('7')).toBe(true);
+    });
+
+    it('returns an empty list if all nodes are already in graph', () => {
+      // Given
+      let nodes = ['3', '2'];
+      let graph = new Dagre.graphlib.Graph({ multigraph: true});
+      graph.setNode('1', {name: 'node1', kind: 'Classs', displayName: 'Node 1'});
+      graph.setNode('2', {name: 'node2', kind: 'Classs', displayName: 'Node 2'});
+      graph.setNode('3', {name: 'node3', kind: 'Classs', displayName: 'Node 3'});
+      graph.setNode('4', {name: 'node4', kind: 'Classs', displayName: 'Node 4'});
+      graph.setNode('5', {name: 'node5', kind: 'Classs', displayName: 'Node 5'});
+
+      // When
+      let result = sut.filterAlreadyInGraph(nodes, graph);
+
+      // Then
+      expect(result.length).toEqual(0);
+    });
+
+  });
+
 });

--- a/test/unit/graph/graph-finder-spec.js
+++ b/test/unit/graph/graph-finder-spec.js
@@ -61,4 +61,50 @@ describe('GraphFinder', () => {
 
   });
 
+  describe('findNodesByEdgeRelationship', () => {
+
+    it('finds source nodes for selected nodes that are the target of "uses" edge kind', () => {
+      // Given
+      let selectedNodeIds = ['3', '4'];
+      let edgeKind = 'uses';
+      let relationship = 'target';
+      let graph = new Dagre.graphlib.Graph({ multigraph: true});
+      let nodes = [
+        {id: '1', name: 'node1', kind: 'Classs', displayName: 'Node 1'},
+        {id: '2', name: 'node2', kind: 'Classs', displayName: 'Node 2'},
+        {id: '3', name: 'node3', kind: 'Classs', displayName: 'Node 3'},
+        {id: '4', name: 'node4', kind: 'Classs', displayName: 'Node 4'},
+        {id: '5', name: 'node5', kind: 'Classs', displayName: 'Node 5'},
+      ];
+      let edges = [
+        {id1: '1', id2: '3', edgeKind: 'uses'},
+        {id1: '2', id2: '3', edgeKind: 'uses'},
+        {id1: '3', id2: '4', edgeKind: 'uses'},
+        {id1: '3', id2: '5', edgeKind: 'uses'},
+      ];
+      nodes.forEach(node => {
+        graph.setNode(node.id, {
+          name:         node.name,
+          kind:         node.kind,
+          displayName:  node.displayName,
+          selectStatus: node.selectStatus
+        });
+      });
+      edges.forEach(edge => {
+        graph.setEdge(edge.id1, edge.id2, { edgeKind: edge.edgeKind });
+      });
+
+      // When
+      let result = sut.findNodesByEdgeRelationship(graph, selectedNodeIds, edgeKind, relationship);
+
+      // Then
+      expect(result.length).toEqual(3);
+      expect(result.includes('1')).toBe(true);
+      expect(result.includes('2')).toBe(true);
+      expect(result.includes('3')).toBe(true);
+
+    });
+
+  });
+
 });

--- a/test/unit/graph/graph-finder-spec.js
+++ b/test/unit/graph/graph-finder-spec.js
@@ -1,0 +1,64 @@
+import {GraphFinder} from '../../../src/graph/graph-finder';
+import Dagre from 'npm:dagre@0.7.4/index.js';
+
+describe('GraphFinder', () => {
+
+  let sut;
+
+  beforeEach( () => {
+    sut = new GraphFinder();
+    expect(sut).toBeDefined();
+  });
+
+  describe('findSelectedNodeIds', () => {
+
+    it('returns array of selected node ids', () => {
+      // Given
+      let graph = new Dagre.graphlib.Graph({ multigraph: true});
+      let nodes = [
+        {id: 1, name: 'node1', kind: 'Classs', displayName: 'Node 1', selectStatus: 'selected' },
+        {id: 2, name: 'node2', kind: 'Classs', displayName: 'Node 2', selectStatus: 'unselected' }
+      ];
+      nodes.forEach(node => {
+        graph.setNode(node.id, {
+          name:         node.name,
+          kind:         node.kind,
+          displayName:  node.displayName,
+          selectStatus: node.selectStatus
+        });
+      });
+
+      // When
+      let result = sut.findSelectedNodeIds(graph);
+
+      // Then
+      expect(result.length).toEqual(1);
+      expect(result[0]).toEqual('1');
+    });
+
+    it('returns empty array when no nodes are selected', () => {
+      // Given
+      let graph = new Dagre.graphlib.Graph({ multigraph: true});
+      let nodes = [
+        {id: 1, name: 'node1', kind: 'Classs', displayName: 'Node 1', selectStatus: 'unselected' },
+        {id: 2, name: 'node2', kind: 'Classs', displayName: 'Node 2', selectStatus: 'unselected' }
+      ];
+      nodes.forEach(node => {
+        graph.setNode(node.id, {
+          name:         node.name,
+          kind:         node.kind,
+          displayName:  node.displayName,
+          selectStatus: node.selectStatus
+        });
+      });
+
+      // When
+      let result = sut.findSelectedNodeIds(graph);
+
+      // Then
+      expect(result.length).toEqual(0);
+    });
+
+  });
+
+});


### PR DESCRIPTION
- Implement all the menu interactions (once 'call' was working, remainder are the same but for different `edgeKind`)
- Undo is working at the same level, for example, if analyzing 'Extensions of Node A' brings in 5 new nodes, then undo-ing this removes those 5 nodes.

Fixes #27 
