### PR TITLE
Feature/40 node text

### DIFF
--- a/src/graph/graph-text-service.js
+++ b/src/graph/graph-text-service.js
@@ -1,0 +1,40 @@
+export class GraphTextService {
+
+  constructor() {
+
+  }
+
+  isUpperCase(char) {
+   return (char >= 'A' && char <= 'Z'); // is this locale safe?
+  }
+
+  splitByLengthAndCamelOrWord(text) {
+    for (let i = 0; i < text.length; i++) {
+      if (i > 0)
+        if ((!this.isUpperCase(text.charAt(i-1)) && this.isUpperCase(text.charAt(i))) || // camel case transition
+           text.charAt(i-1) === ' ')                                           // new word
+              if (i > 3)
+                 return [text.slice(0, i)].concat(this.splitByLengthAndCamelOrWord(text.slice(i)));
+
+       if (i === text.length-1) {
+         return [text];
+       }
+     }
+   }
+
+  formattedText(node) {
+    let text = [],
+      splitName = this.splitByLengthAndCamelOrWord(node.displayName);
+
+    splitName.forEach(function(line, index) {
+     text.push({
+       line: line,
+       x: 0,
+       dy: `${index * 1.2}em`
+     });
+    });
+
+    return text;
+   }
+
+}

--- a/src/graph/graph-text-service.js
+++ b/src/graph/graph-text-service.js
@@ -1,7 +1,7 @@
 export class GraphTextService {
 
   constructor() {
-
+    this.verticalOffset = '1.2em';
   }
 
   isUpperCase(char) {
@@ -26,12 +26,11 @@ export class GraphTextService {
     let text = [],
       splitName = this.splitByLengthAndCamelOrWord(node.displayName);
 
-    splitName.forEach(function(line, index) {
+    splitName.forEach( (line, index) => {
      text.push({
        line: line,
        x: 0,
-      //  dy: `${index * 1.2}em`
-       dy: index === 0 ? '0' : '1.2em'
+       dy: index === 0 ? '0' : this.verticalOffset
      });
     });
 

--- a/src/graph/graph-text-service.js
+++ b/src/graph/graph-text-service.js
@@ -30,7 +30,8 @@ export class GraphTextService {
      text.push({
        line: line,
        x: 0,
-       dy: `${index * 1.2}em`
+      //  dy: `${index * 1.2}em`
+       dy: index === 0 ? '0' : '1.2em'
      });
     });
 

--- a/src/graph/graph-text.js
+++ b/src/graph/graph-text.js
@@ -1,5 +1,6 @@
 /**
  * Utilities for handling graph text
+ * Deprecated, use graph-text-service
  */
 
 function isUpperCase(char) {

--- a/src/node/node-calculator.js
+++ b/src/node/node-calculator.js
@@ -1,0 +1,12 @@
+export class NodeCalculator {
+
+   constructor() { }
+
+   radius(boundingBox, fontSize) {
+    return Math.max(boundingBox.width, boundingBox.height)/2 + fontSize;
+   }
+
+   centerVertically(boundingBox) {
+     return -(boundingBox.height/4);
+   }
+}

--- a/src/node/node.html
+++ b/src/node/node.html
@@ -8,9 +8,16 @@
       <circle class="circle" r="45" fill="${nodeColor()}" stroke="${nodeColor()}" stroke-width="0">
           <title class="tooltip">${toolTip()}</title>
       </circle>
-      <text text-anchor="middle" alignment-baseline="middle" y="-10.69921875" pointer-events="none" style="font-size: 12px; fill: rgb(255, 255, 255); stroke-width: 0px; cursor: pointer;">
-        <tspan x="0" dy="0">${displayNode.kind}</tspan>
-        <tspan x="0" dy="1.2em">${displayNode.name}</tspan>
+      <text text-anchor="middle"
+          alignment-baseline="middle"
+          y="-10.69921875"
+          pointer-events="none"
+          style="font-size: 12px; fill: rgb(255, 255, 255); stroke-width: 0px; cursor: pointer;">
+        <tspan repeat.for="line of displayNodeTextLines"
+          x.bind="line.x"
+          dy.bind="line.dy">
+            ${line.line}
+        </tspan>
       </text>
     </g>
   </svg>

--- a/src/node/node.html
+++ b/src/node/node.html
@@ -14,7 +14,7 @@
       </circle>
       <text text-anchor="middle"
           alignment-baseline="middle"
-          y="-10.69921875"
+          y="${centerTextAtY}"
           pointer-events="none"
           style="font-size: 12px; fill: rgb(255, 255, 255); stroke-width: 0px; cursor: pointer;">
         <tspan repeat.for="line of displayNodeTextLines"

--- a/src/node/node.html
+++ b/src/node/node.html
@@ -5,7 +5,11 @@
         id="node-${displayNode.id}"
         click.delegate="toggleSelected($event)"
         transform="translate(${displayNode.x},${displayNode.y})">
-      <circle class="circle" r="45" fill="${nodeColor()}" stroke="${nodeColor()}" stroke-width="0">
+      <circle class="circle"
+        r="${expandedRadius}"
+        fill="${nodeColor()}"
+        stroke="${nodeColor()}"
+        stroke-width="0">
           <title class="tooltip">${toolTip()}</title>
       </circle>
       <text text-anchor="middle"

--- a/src/node/node.html
+++ b/src/node/node.html
@@ -16,7 +16,7 @@
           alignment-baseline="middle"
           y="${centerTextAtY}"
           pointer-events="none"
-          style="font-size: 12px; fill: rgb(255, 255, 255); stroke-width: 0px; cursor: pointer;">
+          style="font-size: ${nodeFontSize}px; fill: rgb(255, 255, 255); stroke-width: 0px; cursor: pointer;">
         <tspan repeat.for="line of displayNodeTextLines"
           x.bind="line.x"
           dy.bind="line.dy">

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -35,17 +35,22 @@ export class Node {
     }
   }
 
-  // Delay the bounding box calculation to the end when svg is actually appended to body
+  // Use micro task queue to delay bounding box calculation until AFTER svg is appended to body
   expandNode() {
     this.taskQueue.queueMicroTask(() => {
       let sphereFontSize = 12; // FIXME where should this be defined?
       let svgRect = this.$node[0].getBBox();
       this.displayNode.expandedRadius = Math.max(svgRect.width, svgRect.height)/2 + sphereFontSize;
+      this.displayNode.centerTextAtY = -(svgRect.height/4);
     });
   }
 
+  // These attributes use dirty checking because they can only be calculated after svg is appended to body
   get expandedRadius() {
-    return this.displayNode.expandedRadius || 5;
+    return this.displayNode.expandedRadius;
+  }
+  get centerTextAtY() {
+    return this.displayNode.centerTextAtY;
   }
 
   toolTip() {

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -3,22 +3,25 @@ import {BindingEngine} from 'aurelia-binding';
 import $ from 'jquery';
 import 'npm:gsap@1.18.0/src/minified/TweenMax.min.js';
 import d3 from 'd3';
+import {GraphTextService} from '../graph/graph-text-service';
 import {fillColor} from './node-style';
 
 @customElement('node')
 @containerless
-@inject(Element, BindingEngine)
+@inject(Element, BindingEngine, GraphTextService)
 export class Node {
   @bindable data;
 
-  constructor(element, bindingEngine) {
+  constructor(element, bindingEngine, graphTextService) {
     this.element = element;
     this.bindingEngine = bindingEngine;
+    this.graphTextService = graphTextService;
   }
 
   dataChanged(newVal) {
     if (newVal) {
       this.displayNode = newVal;
+      this.displayNodeTextLines = this.graphTextService.formattedText(this.displayNode);
 
       this.bindingEngine.propertyObserver(this.displayNode, 'x').subscribe((newValue, oldValue) => {
         this.animateX(this.$node, oldValue, newValue);

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -4,19 +4,21 @@ import $ from 'jquery';
 import 'npm:gsap@1.18.0/src/minified/TweenMax.min.js';
 import d3 from 'd3';
 import {GraphTextService} from '../graph/graph-text-service';
+import {NodeCalculator} from './node-calculator';
 import {fillColor} from './node-style';
 
 @customElement('node')
 @containerless
-@inject(Element, BindingEngine, GraphTextService, TaskQueue)
+@inject(Element, BindingEngine, GraphTextService, TaskQueue, NodeCalculator)
 export class Node {
   @bindable data;
 
-  constructor(element, bindingEngine, graphTextService, taskQueue) {
+  constructor(element, bindingEngine, graphTextService, taskQueue, nodeCalculator) {
     this.element = element;
     this.bindingEngine = bindingEngine;
     this.graphTextService = graphTextService;
     this.taskQueue = taskQueue;
+    this.nodeCalculator = nodeCalculator;
     this.nodeFontSize = 12;
   }
 
@@ -36,12 +38,12 @@ export class Node {
     }
   }
 
-  // Use micro task queue to delay bounding box calculation until AFTER svg is appended to body
+  // Use micro task queue to delay calculations until AFTER svg is appended to body
   expandNode() {
     this.taskQueue.queueMicroTask(() => {
       let svgRect = this.$node[0].getBBox();
-      this.displayNode.expandedRadius = Math.max(svgRect.width, svgRect.height)/2 + this.nodeFontSize;
-      this.displayNode.centerTextAtY = -(svgRect.height/4);
+      this.displayNode.expandedRadius = this.nodeCalculator.radius(svgRect, this.nodeFontSize);
+      this.displayNode.centerTextAtY = this.nodeCalculator.centerVertically(svgRect);
     });
   }
 

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -17,6 +17,7 @@ export class Node {
     this.bindingEngine = bindingEngine;
     this.graphTextService = graphTextService;
     this.taskQueue = taskQueue;
+    this.nodeFontSize = 12;
   }
 
   dataChanged(newVal) {
@@ -38,9 +39,8 @@ export class Node {
   // Use micro task queue to delay bounding box calculation until AFTER svg is appended to body
   expandNode() {
     this.taskQueue.queueMicroTask(() => {
-      let sphereFontSize = 12; // FIXME where should this be defined?
       let svgRect = this.$node[0].getBBox();
-      this.displayNode.expandedRadius = Math.max(svgRect.width, svgRect.height)/2 + sphereFontSize;
+      this.displayNode.expandedRadius = Math.max(svgRect.width, svgRect.height)/2 + this.nodeFontSize;
       this.displayNode.centerTextAtY = -(svgRect.height/4);
     });
   }

--- a/test/unit/graph/graph-text-service-spec.js
+++ b/test/unit/graph/graph-text-service-spec.js
@@ -9,7 +9,7 @@ describe('GraphTextService', () => {
       graphTextService = new GraphTextService();
     });
 
-    it('splits into lines by camel case', () => {
+    it('splits into lines by spaces and camelCase', () => {
       // Given
       let node = { displayName: 'class SingletonIo' };
 
@@ -24,11 +24,43 @@ describe('GraphTextService', () => {
 
       expect(result[1].line).toEqual('Singleton');
       expect(result[1].x).toEqual(0);
-      expect(result[1].dy).toEqual('1.2em');
+      expect(result[1].dy).toEqual(graphTextService.verticalOffset);
 
       expect(result[2].line).toEqual('Io');
       expect(result[2].x).toEqual(0);
-      expect(result[2].dy).toEqual('1.2em');
+      expect(result[2].dy).toEqual(graphTextService.verticalOffset);
+    });
+
+    it('splits into one line for single word', () => {
+      // Given
+      let node = { displayName: 'constructor' };
+
+      // When
+      let result = graphTextService.formattedText(node);
+
+      // Then
+      expect(result.length).toEqual(1);
+      expect(result[0].line).toEqual('constructor');
+      expect(result[0].x).toEqual(0);
+      expect(result[0].dy).toEqual('0');
+    });
+
+    it('splits into two lines for space and no camel casing', () => {
+      // Given
+      let node = { displayName: 'value evidence$2' };
+
+      // When
+      let result = graphTextService.formattedText(node);
+
+      // Then
+      expect(result.length).toEqual(2);
+      expect(result[0].line).toEqual('value ');
+      expect(result[0].x).toEqual(0);
+      expect(result[0].dy).toEqual('0');
+
+      expect(result[1].line).toEqual('evidence$2');
+      expect(result[1].x).toEqual(0);
+      expect(result[1].dy).toEqual(graphTextService.verticalOffset);
     });
 
   });

--- a/test/unit/graph/graph-text-service-spec.js
+++ b/test/unit/graph/graph-text-service-spec.js
@@ -9,7 +9,7 @@ describe('GraphTextService', () => {
       graphTextService = new GraphTextService();
     });
 
-    it('splits into lines by camel case and increments vertical offset', () => {
+    it('splits into lines by camel case', () => {
       // Given
       let node = { displayName: 'class SingletonIo' };
 
@@ -20,7 +20,7 @@ describe('GraphTextService', () => {
       expect(result.length).toEqual(3);
       expect(result[0].line).toEqual('class ');
       expect(result[0].x).toEqual(0);
-      expect(result[0].dy).toEqual('0em');
+      expect(result[0].dy).toEqual('0');
 
       expect(result[1].line).toEqual('Singleton');
       expect(result[1].x).toEqual(0);
@@ -28,7 +28,7 @@ describe('GraphTextService', () => {
 
       expect(result[2].line).toEqual('Io');
       expect(result[2].x).toEqual(0);
-      expect(result[2].dy).toEqual('2.4em');
+      expect(result[2].dy).toEqual('1.2em');
     });
 
   });

--- a/test/unit/graph/graph-text-service-spec.js
+++ b/test/unit/graph/graph-text-service-spec.js
@@ -1,0 +1,36 @@
+import {GraphTextService} from '../../../src/graph/graph-text-service';
+
+describe('GraphTextService', () => {
+
+  describe('formattedText', () => {
+    let graphTextService;
+
+    beforeEach(() => {
+      graphTextService = new GraphTextService();
+    });
+
+    it('splits into lines by camel case and increments vertical offset', () => {
+      // Given
+      let node = { displayName: 'class SingletonIo' };
+
+      // When
+      let result = graphTextService.formattedText(node);
+
+      // Then
+      expect(result.length).toEqual(3);
+      expect(result[0].line).toEqual('class ');
+      expect(result[0].x).toEqual(0);
+      expect(result[0].dy).toEqual('0em');
+
+      expect(result[1].line).toEqual('Singleton');
+      expect(result[1].x).toEqual(0);
+      expect(result[1].dy).toEqual('1.2em');
+
+      expect(result[2].line).toEqual('Io');
+      expect(result[2].x).toEqual(0);
+      expect(result[2].dy).toEqual('2.4em');
+    });
+
+  });
+
+});

--- a/test/unit/node/node-calculator-spec.js
+++ b/test/unit/node/node-calculator-spec.js
@@ -1,0 +1,53 @@
+import {NodeCalculator} from '../../../src/node/node-calculator';
+
+describe('NodeCalculator', () => {
+  let nodeCalculator;
+
+  beforeEach( () => {
+    nodeCalculator = new NodeCalculator();
+  });
+
+  describe('radius', () => {
+
+    it('is a function of font size, and width when greater than height', () => {
+      // Given
+      let boundingBox = { width: 10, height: 5};
+      let fontSize = 2;
+
+      // When
+      let result = nodeCalculator.radius(boundingBox, fontSize);
+
+      // Then
+      expect(result).toEqual(7);
+    });
+
+    it('is a function of font size, and height when greater than width', () => {
+      // Given
+      let boundingBox = { width: 10, height: 20};
+      let fontSize = 2;
+
+      // When
+      let result = nodeCalculator.radius(boundingBox, fontSize);
+
+      // Then
+      expect(result).toEqual(12);
+    });
+
+  });
+
+  describe('centerVertically', () => {
+
+    it('is a function of height', () => {
+      // Given
+      let boundingBox = { width: 20, height: 40};
+
+      // When
+      let result = nodeCalculator.centerVertically(boundingBox);
+
+      // Then
+      expect(result).toEqual(-10);
+    });
+
+  });
+
+});


### PR DESCRIPTION
- display text in node is now split into lines via GraphTextService (old rules from legacy now in unit testable format)
- a repeater in Node custom element iterates over the lines to generate `<tspan>` elements
- bounding box is determined after all text lines for a given node are appended to body, using Aurelia's micro task queue
- node calculations for radius and centering text are extracted to NodeCalculator and unit tested

Fixes #40 
