### PR TITLE
Feature/48 highlight edges

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,6 +13,7 @@
     "beforeEach": false,
     "it": false,
     "expect": false,
+    "spyOn": false,
     "TweenLite": false,
     "Linear": false,
     "Elastic": false,

--- a/src/edge/edge.html
+++ b/src/edge/edge.html
@@ -8,7 +8,7 @@
       y2="${displayEdge.target.y}"
       stroke-dasharray="${edgeStrokeDashArray()}"
       stroke="${edgeColor()}"
-      stroke-width="${edgeWidth()}">
+      stroke-width="${edgeWidth}">
     </line>
   </svg>
 

--- a/src/edge/edge.html
+++ b/src/edge/edge.html
@@ -7,7 +7,7 @@
       x2="${displayEdge.target.x}"
       y2="${displayEdge.target.y}"
       stroke-dasharray="${edgeStrokeDashArray()}"
-      stroke="${edgeColor()}"
+      stroke="${edgeColor}"
       stroke-width="${edgeWidth}">
     </line>
   </svg>

--- a/src/edge/edge.html
+++ b/src/edge/edge.html
@@ -14,7 +14,7 @@
       font-size="14"
       x="40"
       y="100"
-      stroke="${edgeColor}">
+      stroke="#787878">
         <textPath xlink:href="#${edgePathId}">
           ${displayEdge.edgeKind}
         </textPath>

--- a/src/edge/edge.html
+++ b/src/edge/edge.html
@@ -1,15 +1,25 @@
 <template>
 
   <svg>
-    <line class="edge" id="edge-${displayEdge.source.id}-${displayEdge.target.id}"
-      x1="${displayEdge.source.x}"
-      y1="${displayEdge.source.y}"
-      x2="${displayEdge.target.x}"
-      y2="${displayEdge.target.y}"
+    <defs>
+      <path id="${edgePathId}"
+        d="${edgePathForText}"/>
+    </defs>
+    <path class="edge" id="edge-${displayEdge.source.id}-${displayEdge.target.id}"
+      d="M${displayEdge.source.x} ${displayEdge.source.y} L${displayEdge.target.x} ${displayEdge.target.y}"
       stroke-dasharray="${edgeStrokeDashArray()}"
       stroke="${edgeColor}"
-      stroke-width="${edgeWidth}">
-    </line>
+      stroke-width="${edgeWidth}"/>
+    <text
+      font-size="14"
+      x="40"
+      y="100"
+      stroke="${edgeColor}">
+        <textPath xlink:href="#${edgePathId}">
+          ${displayEdge.edgeKind}
+        </textPath>
+    </text>
+
   </svg>
 
 </template>

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -90,23 +90,31 @@ export class Edge {
     return this.edgeStyle.strokeColor(this.displayEdge.edgeKind);
   }
 
-  // This may vary with highlight status?
-  edgeWidth() {
-    return 1;
+  get edgeWidth() {
+    if (this.displayEdge.highlight) {
+      return 10;
+    } else {
+      return 1;
+    }
   }
 
   registerEvents() {
-    this.nodeHoverInSub = this.eventAggregator.subscribe('node.hover.in', this.highlightEdges);
-    this.nodeHoverOutSub = this.eventAggregator.subscribe('node.hover.out', this.unHighlightEdges);
+    this.nodeHoverInSub = this.eventAggregator.subscribe('node.hover.in', this.highlightEdges.bind(this));
+    this.nodeHoverOutSub = this.eventAggregator.subscribe('node.hover.out', this.unHighlightEdges.bind(this));
   }
 
   highlightEdges(node) {
-    console.log(`=== HIGHLIGHT EDGES FOR NODE: ${node.displayName}`);
+    if (this.displayEdge.source.id === node.id || this.displayEdge.target.id === node.id) {
+      console.log(`=== SHOULD HIGHLIGHT ${node.id}`);
+      this.displayEdge.highlight = true;
+    }
   }
 
   unHighlightEdges(node) {
-    console.log(`=== UN HIGHLIGHT EDGES FOR NODE: ${node.displayName}`);
-
+    if (this.displayEdge.source.id === node.id || this.displayEdge.target.id === node.id) {
+      console.log(`=== SHOULD UNHIGHLIGHT ${node.id}`);
+      this.displayEdge.highlight = false;
+    }
   }
 
   detached() {

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -6,6 +6,7 @@ import {EdgeStyle} from './edge-style';
 
 const EDGE_ANIMATE_DURATION = 0.5;
 const EDGE_ANIMATE_EASE = Power1.easeIn;
+const EDGE_ANIMATE_DELAY = 1;
 
 const HIGHLIGHT_COLOR_SOURCE = 'orange';
 const HIGHLIGHT_COLOR_TARGET = 'yellow';
@@ -40,7 +41,8 @@ export class Edge {
     // Animate edge target from source point
     TweenLite.from(this.$edge[0], EDGE_ANIMATE_DURATION, {
       attr: {x2: this.displayEdge.source.x, y2: this.displayEdge.source.y},
-      ease: EDGE_ANIMATE_EASE
+      ease: EDGE_ANIMATE_EASE,
+      delay: EDGE_ANIMATE_DELAY
     });
 
     this.registerEvents();
@@ -50,7 +52,7 @@ export class Edge {
     if (newVal && oldVal) {
       TweenLite.from(this.$edge[0], EDGE_ANIMATE_DURATION, {
         attr: {x1: oldVal},
-        ease: EDGE_ANIMATE_EASE,
+        ease: EDGE_ANIMATE_EASE
       });
     }
   }
@@ -59,7 +61,7 @@ export class Edge {
     if (newVal && oldVal) {
       TweenLite.from(this.$edge[0], EDGE_ANIMATE_DURATION, {
         attr: {y1: oldVal},
-        ease: EDGE_ANIMATE_EASE,
+        ease: EDGE_ANIMATE_EASE
       });
     }
   }

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -86,13 +86,17 @@ export class Edge {
     return this.edgeStyle.strokeDash(this.displayEdge.edgeKind);
   }
 
-  edgeColor() {
-    return this.edgeStyle.strokeColor(this.displayEdge.edgeKind);
+  get edgeColor() {
+    if (this.displayEdge.highlight) {
+        return 'orange';
+    } else {
+      return this.edgeStyle.strokeColor(this.displayEdge.edgeKind);
+    }
   }
 
   get edgeWidth() {
     if (this.displayEdge.highlight) {
-      return 10;
+      return 5;
     } else {
       return 1;
     }

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -7,6 +7,10 @@ import {EdgeStyle} from './edge-style';
 const EDGE_ANIMATE_DURATION = 0.5;
 const EDGE_ANIMATE_EASE = Power1.easeIn;
 
+const HIGHLIGHT_COLOR_SOURCE = 'orange';
+const HIGHLIGHT_COLOR_TARGET = 'yellow';
+const HIGHLIGHT_WIDTH = 5;
+
 @customElement('edge')
 @containerless
 @inject(Element, EventAggregator, EdgeStyle)
@@ -87,16 +91,18 @@ export class Edge {
   }
 
   get edgeColor() {
-    if (this.displayEdge.highlight) {
-        return 'orange';
+    if (this.displayEdge.highlightSource) {
+        return HIGHLIGHT_COLOR_SOURCE;
+    } else if (this.displayEdge.highlightTarget) {
+      return HIGHLIGHT_COLOR_TARGET;
     } else {
       return this.edgeStyle.strokeColor(this.displayEdge.edgeKind);
     }
   }
 
   get edgeWidth() {
-    if (this.displayEdge.highlight) {
-      return 5;
+    if (this.displayEdge.highlightSource || this.displayEdge.highlightTarget) {
+      return HIGHLIGHT_WIDTH;
     } else {
       return 1;
     }
@@ -108,16 +114,20 @@ export class Edge {
   }
 
   highlightEdges(node) {
-    if (this.displayEdge.source.id === node.id || this.displayEdge.target.id === node.id) {
-      console.log(`=== SHOULD HIGHLIGHT ${node.id}`);
-      this.displayEdge.highlight = true;
+    if (this.displayEdge.source.id === node.id) {
+      this.displayEdge.highlightSource = true;
+    }
+    if (this.displayEdge.target.id === node.id) {
+      this.displayEdge.highlightTarget = true;
     }
   }
 
   unHighlightEdges(node) {
-    if (this.displayEdge.source.id === node.id || this.displayEdge.target.id === node.id) {
-      console.log(`=== SHOULD UNHIGHLIGHT ${node.id}`);
-      this.displayEdge.highlight = false;
+    if (this.displayEdge.source.id === node.id) {
+      this.displayEdge.highlightSource = false;
+    }
+    if (this.displayEdge.target.id === node.id) {
+      this.displayEdge.highlightTarget = false;
     }
   }
 
@@ -126,7 +136,8 @@ export class Edge {
   }
 
   deregisterEvents() {
-
+    this.nodeHoverInSub.dispose();
+    this.nodeHoverOutSub.dispose();
   }
 
 }

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -38,7 +38,7 @@ export class Edge {
     return `#edge-path-${this.displayEdge.source.id}-${this.displayEdge.target.id}`;
   }
 
-  // FIXME Detect if need to flip the text to not be upside down http://stackoverflow.com/questions/16672569/d3-js-upside-down-path-text
+  // FIXME handle upside down https://github.com/CANVE/canve-viz/issues/54
   get edgePathForText() {
     return `M${this.displayEdge.source.x} ${this.displayEdge.source.y} L${this.displayEdge.target.x} ${this.displayEdge.target.y}`;
   }

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -9,7 +9,7 @@ const EDGE_ANIMATE_EASE = Power1.easeIn;
 const EDGE_ANIMATE_DELAY = 1;
 
 const HIGHLIGHT_COLOR_SOURCE = 'orange';
-const HIGHLIGHT_COLOR_TARGET = 'yellow';  // FIXME yellow is hard to read on white
+const HIGHLIGHT_COLOR_TARGET = 'rgb(60, 234, 245)';
 const HIGHLIGHT_WIDTH = 5;
 
 @customElement('edge')

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -1,4 +1,5 @@
 import {inject, customElement, bindable, containerless} from 'aurelia-framework';
+import {EventAggregator} from 'aurelia-event-aggregator';
 import $ from 'jquery';
 import 'npm:gsap@1.18.0/src/minified/TweenMax.min.js';
 import {EdgeStyle} from './edge-style';
@@ -8,7 +9,7 @@ const EDGE_ANIMATE_EASE = Power1.easeIn;
 
 @customElement('edge')
 @containerless
-@inject(Element, EdgeStyle)
+@inject(Element, EventAggregator, EdgeStyle)
 export class Edge {
   @bindable data;
   @bindable sourcex;
@@ -16,8 +17,9 @@ export class Edge {
   @bindable targetx;
   @bindable targety;
 
-  constructor(element, edgeStyle) {
+  constructor(element, eventAggregator, edgeStyle) {
     this.element = element;
+    this.eventAggregator = eventAggregator;
     this.edgeStyle = edgeStyle;
   }
 
@@ -37,6 +39,7 @@ export class Edge {
       ease: EDGE_ANIMATE_EASE
     });
 
+    this.registerEvents();
   }
 
   sourcexChanged(newVal, oldVal) {
@@ -90,6 +93,28 @@ export class Edge {
   // This may vary with highlight status?
   edgeWidth() {
     return 1;
+  }
+
+  registerEvents() {
+    this.nodeHoverInSub = this.eventAggregator.subscribe('node.hover.in', this.highlightEdges);
+    this.nodeHoverOutSub = this.eventAggregator.subscribe('node.hover.out', this.unHighlightEdges);
+  }
+
+  highlightEdges(node) {
+    console.log(`=== HIGHLIGHT EDGES FOR NODE: ${node.displayName}`);
+  }
+
+  unHighlightEdges(node) {
+    console.log(`=== UN HIGHLIGHT EDGES FOR NODE: ${node.displayName}`);
+
+  }
+
+  detached() {
+    this.deregisterEvents();
+  }
+
+  deregisterEvents() {
+
   }
 
 }

--- a/src/edge/edge.js
+++ b/src/edge/edge.js
@@ -9,7 +9,7 @@ const EDGE_ANIMATE_EASE = Power1.easeIn;
 const EDGE_ANIMATE_DELAY = 1;
 
 const HIGHLIGHT_COLOR_SOURCE = 'orange';
-const HIGHLIGHT_COLOR_TARGET = 'yellow';
+const HIGHLIGHT_COLOR_TARGET = 'yellow';  // FIXME yellow is hard to read on white
 const HIGHLIGHT_WIDTH = 5;
 
 @customElement('edge')
@@ -34,6 +34,16 @@ export class Edge {
     }
   }
 
+  get edgePathId() {
+    return `#edge-path-${this.displayEdge.source.id}-${this.displayEdge.target.id}`;
+  }
+
+  // FIXME Detect if need to flip the text to not be upside down http://stackoverflow.com/questions/16672569/d3-js-upside-down-path-text
+  get edgePathForText() {
+    return `M${this.displayEdge.source.x} ${this.displayEdge.source.y} L${this.displayEdge.target.x} ${this.displayEdge.target.y}`;
+  }
+
+  // FIXME Now that have switched from line to path, redo animation to animate path, GSAP may have plugin for this
   attached() {
     // Selector
     this.$edge = $(`#edge-${this.displayEdge.source.id}-${this.displayEdge.target.id}`);

--- a/styles/edge.css
+++ b/styles/edge.css
@@ -1,3 +1,14 @@
+/* FIXME https://github.com/CANVE/canve-viz/issues/55 */
+/* Animate edges but this breaks dash styling to indicate edgeKind */
 .edge {
-  stroke-opacity: .6
+  stroke-opacity: .6;
+  /*stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: dash 5s linear forwards;*/
+}
+
+@keyframes dash {
+  to {
+    stroke-dashoffset: 0;
+  }
 }

--- a/test/unit/edge/edge-spec.js
+++ b/test/unit/edge/edge-spec.js
@@ -34,7 +34,7 @@ describe('Edge', function() {
       edge.dataChanged(displayEdge);
 
       // Then
-      expect(edge.edgeColor).toEqual('yellow');
+      expect(edge.edgeColor).toEqual('rgb(60, 234, 245)');
     });
 
     it('Returns color based on edge style', () => {

--- a/test/unit/edge/edge-spec.js
+++ b/test/unit/edge/edge-spec.js
@@ -52,4 +52,36 @@ describe('Edge', function() {
 
   });
 
+  describe('highlightEdges', () => {
+
+    it('Sets edge to be highlighted as source', () => {
+      // Given
+      let node = { id: '111'};
+      let displayEdge = { source: {id: '111'}, target: {id: '222'}};
+
+      // When
+      edge.dataChanged(displayEdge);
+      edge.highlightEdges(node);
+
+      // Then
+      expect(edge.displayEdge.highlightSource).toBe(true);
+      expect(edge.displayEdge.highlightTarget).toBeUndefined();
+    });
+
+    it('Sets edge to be highlighted as target', () => {
+      // Given
+      let node = { id: '222'};
+      let displayEdge = { source: {id: '111'}, target: {id: '222'}};
+
+      // When
+      edge.dataChanged(displayEdge);
+      edge.highlightEdges(node);
+
+      // Then
+      expect(edge.displayEdge.highlightTarget).toBe(true);
+      expect(edge.displayEdge.highlightSource).toBeUndefined();
+    });
+
+  });
+
 });

--- a/test/unit/edge/edge-spec.js
+++ b/test/unit/edge/edge-spec.js
@@ -1,0 +1,55 @@
+import {Edge} from '../../../src/edge/edge';
+
+describe('Edge', function() {
+  const edgeStyleColor = 'grey';
+  let edge, mockElement, mockEventAggregator, mockEdgeStyle;
+
+  beforeEach( () => {
+    mockElement = {};
+    mockEventAggregator = {};
+    mockEdgeStyle = {
+      strokeColor: function() { return edgeStyleColor; }
+    };
+    edge = new Edge(mockElement, mockEventAggregator, mockEdgeStyle);
+  });
+
+  describe('edgeColor', () => {
+
+    it('Returns highlight color for source', () => {
+      // Given
+      let displayEdge = { edgeKind: 'extends', highlightSource: true };
+
+      // When
+      edge.dataChanged(displayEdge);
+
+      // Then
+      expect(edge.edgeColor).toEqual('orange');
+    });
+
+    it('Returns highlight color for target', () => {
+      // Given
+      let displayEdge = { edgeKind: 'extends', highlightTarget: true };
+
+      // When
+      edge.dataChanged(displayEdge);
+
+      // Then
+      expect(edge.edgeColor).toEqual('yellow');
+    });
+
+    it('Returns color based on edge style', () => {
+      // Given
+      spyOn(mockEdgeStyle, 'strokeColor').and.callThrough();
+      let displayEdge = { edgeKind: 'extends'};
+
+      // When
+      edge.dataChanged(displayEdge);
+
+      // Then
+      expect(edge.edgeColor).toEqual(edgeStyleColor);
+      expect(mockEdgeStyle.strokeColor).toHaveBeenCalled();
+    });
+
+  });
+
+});


### PR DESCRIPTION
When a node is hovered over, all its source and target edges are highlighted, with a different color for source vs target highlighting.

Also introduced text label displaying edgeKind along each edge. Another issue is opened to improve this feature #54.

Converted edges from svg line to path, in anticipation of future requirement to handle multi-graph #53.

Fixes #48 
